### PR TITLE
security: fix shell-command-injection-from-environment (v3.5.1)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.5.1] - 2026-07-26
+
+### Security
+- **Fix CodeQL `js/shell-command-injection-from-environment` alert** in `--doctor` check
+  - Replace `runCommandSafe('sh', ['-c', \`command -v ${command}\`])` with direct execution
+  - Absolute paths (e.g. `process.execPath`) are now checked via `fs.existsSync()` — no shell involved
+  - Bare command names (`zsh`, `git`) are probed with `runCommandSafe(command, ['--version'], { stdio: 'ignore' })` — `execFileSync` with an argument array, immune to shell metacharacter injection
+- **`runCommandSafe` now respects `options.stdio`**
+  - When `stdio: 'ignore'` or `'pipe'` is passed, suppresses `🚀 Running:` and `✅/❌` console output
+  - Enables silent probing without leaking noise to the user's terminal
+
 ## [3.5.0] - 2026-07-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-lazy-zsh",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Awesome-Lazy-Zsh is a streamlined Zsh setup tool, designed for easy customization of your terminal environment.",
   "main": "src/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -422,7 +422,12 @@ async function main() {
             ];
             let healthy = true;
             for (const [name, command] of checks) {
-                const available = command.includes('/') ? fs.existsSync(command) : await runCommandSafe('sh', ['-c', `command -v ${command}`]);
+                // For absolute paths (e.g. process.execPath), check existence directly.
+                // For bare names, probe with --version to avoid constructing a shell string
+                // from environment values (guards against shell injection via execPath).
+                const available = command.includes('/')
+                    ? fs.existsSync(command)
+                    : await runCommandSafe(command, ['--version'], { stdio: 'ignore' });
                 console.log(`${available ? 'OK' : 'MISSING'} ${name}`);
                 healthy &&= Boolean(available);
             }

--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -41,21 +41,29 @@ export function runCommand(command) {
  */
 export function runCommandSafe(binary, args, options = {}) {
     return new Promise((resolve) => {
+        const stdio = options.stdio || 'inherit';
+        const silent = stdio === 'ignore' || stdio === 'pipe';
         try {
-            const displayCmd = `${binary} ${args.join(' ')}`;
-            console.log(chalk.blue(`🚀 Running: ${displayCmd}`));
+            if (!silent) {
+                const displayCmd = `${binary} ${args.join(' ')}`;
+                console.log(chalk.blue(`🚀 Running: ${displayCmd}`));
+            }
             execFileSync(binary, args, {
-                stdio: 'inherit',
+                stdio,
                 timeout: options.timeout || 60000,
                 cwd: options.cwd || undefined,
                 env: options.env || process.env
             });
-            console.log(chalk.green(`✅ Command executed successfully`));
+            if (!silent) {
+                console.log(chalk.green(`✅ Command executed successfully`));
+            }
             resolve(true);
         } catch (error) {
-            const displayCmd = `${binary} ${args.join(' ')}`;
-            console.error(chalk.red(`❌ Command failed: ${displayCmd}`));
-            console.error(chalk.red(`Error: ${error.message}`));
+            if (!silent) {
+                const displayCmd = `${binary} ${args.join(' ')}`;
+                console.error(chalk.red(`❌ Command failed: ${displayCmd}`));
+                console.error(chalk.red(`Error: ${error.message}`));
+            }
             resolve(false);
         }
     });


### PR DESCRIPTION
## Summary

Resolves CodeQL alert js/shell-command-injection-from-environment.

## Changes

**src/index.js** — doctor check loop: replace sh -c with direct execution. Absolute paths use fs.existsSync; bare names (zsh, git) use runCommandSafe(cmd, ['--version'], { stdio: 'ignore' }) — execFileSync with arg array, no shell interpolation.

**src/utils/commands.js** — runCommandSafe now respects options.stdio. Suppresses console output when stdio is ignore or pipe.

## Version
3.5.0 -> 3.5.1