### PR TITLE
fix: verify Homebrew upgrade actually installed expected version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.5.2] - 2026-08-02
+
+### Fixed
+- **Homebrew upgrade verification** - `brew upgrade` now verifies the installed version matches the expected release
+  - Previously, `brew upgrade` would report success even when the Homebrew formula hadn't been updated yet
+  - Now checks `brew info --json=v2` after upgrade to confirm the version actually changed
+  - Displays clear warning when Homebrew formula is out of sync with GitHub release
+
 ## [3.5.1] - 2026-07-26
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-lazy-zsh",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Awesome-Lazy-Zsh is a streamlined Zsh setup tool, designed for easy customization of your terminal environment.",
   "main": "src/index.js",
   "type": "module",

--- a/src/utils/updateChecker.js
+++ b/src/utils/updateChecker.js
@@ -384,6 +384,28 @@ export async function performUpdate(installMethod, latestVersion, commandRunner 
                 console.log(chalk.red(`❌ brew upgrade failed: ${brewResult.output}`));
                 return { success: false, message: brewResult.output };
             }
+
+            // Verify the upgrade actually installed the expected version
+            // brew upgrade succeeds even when formula hasn't been updated yet
+            const infoResult = await commandRunner('brew', ['info', '--json=v2', 'awesome-lazy-zsh']);
+            if (infoResult.success) {
+                try {
+                    const info = JSON.parse(infoResult.output);
+                    const installedVersion = info.formulae?.[0]?.installed?.[0]?.version;
+                    if (installedVersion && installedVersion !== latestVersion) {
+                        console.log(chalk.yellow(`⚠️ Homebrew formula not yet updated to v${latestVersion}.`));
+                        console.log(chalk.yellow(`   Currently installed: v${installedVersion}`));
+                        console.log(chalk.yellow(`   The Homebrew formula may take some time to sync with the GitHub release.`));
+                        return { 
+                            success: false, 
+                            message: `Homebrew formula is still at v${installedVersion}. The formula may not be updated yet for v${latestVersion}.` 
+                        };
+                    }
+                } catch {
+                    // JSON parse failed, continue with success
+                }
+            }
+
             console.log(chalk.green('✅ Updated via Homebrew.'));
             return { success: true, message: 'Updated successfully via brew upgrade.' };
         }


### PR DESCRIPTION
## Summary
`brew upgrade` exits 0 even when formula hasn't been updated yet.

## Changes
- Now checks `brew info --json=v2` post-upgrade to verify the installed version matches the expected `latestVersion`
- Shows a clear warning if the Homebrew formula is out of sync with the GitHub release

## Testing
- All 144 tests pass
- Lint passes

## Version
Bumps to v3.5.2